### PR TITLE
IPv6 support for SRS

### DIFF
--- a/trunk/configure
+++ b/trunk/configure
@@ -82,7 +82,7 @@ done
 #####################################################################################
 # build tools or compiler args.
 # enable gdb debug
-GDBDebug=" -g -O0"
+GDBDebug=" -g -O1"
 # the warning level.
 WarnLevel=" -Wall"
 # the compile standard.

--- a/trunk/src/app/srs_app_listener.cpp
+++ b/trunk/src/app/srs_app_listener.cpp
@@ -128,6 +128,7 @@ int SrsUdpListener::listen()
         return ret;
     }
     puts("XXX-9-LISTEN-OK!");
+    printf("XXX-9- F=%d\n", result->ai_family);
     
     if ((_fd = socket(result->ai_family, result->ai_socktype, result->ai_protocol)) == -1) {
         ret = ERROR_SOCKET_CREATE;
@@ -204,7 +205,7 @@ SrsTcpListener::SrsTcpListener(ISrsTcpHandler* h, string i, int p)
     handler = h;
     ip = i;
     port = p;
-
+    
     _fd = -1;
     _stfd = NULL;
 
@@ -237,19 +238,20 @@ int SrsTcpListener::listen()
     snprintf(port_string, sizeof(port_string), "%d", port);
     addrinfo hints;
     memset(&hints, 0, sizeof(hints));
-    hints.ai_family   = AF_UNSPEC;
+    hints.ai_family   = srs_check_ipv6() ? AF_INET6 : AF_INET;
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_flags    = AI_NUMERICHOST;
     addrinfo* result  = NULL;
-    puts("XXX-9");
+    printf("XXX-9b <ip=%s>",ip.c_str());
     if(getaddrinfo(ip.c_str(), port_string, (const addrinfo*)&hints, &result) != 0) {
         ret = ERROR_SYSTEM_IP_INVALID;
-        puts("XXX-9-BAD!!!");
+        puts("XXX-9b-BAD!!!");
         srs_error("bad address. ret=%d", ret);
         return ret;
     }
-    puts("XXX-9-LISTEN-OK!");
-    
+    puts("XXX-9b-LISTEN-OK!");
+    printf("XXX-9b- F=%d\n", result->ai_family);
+
     if ((_fd = socket(result->ai_family, result->ai_socktype, result->ai_protocol)) == -1) {
         ret = ERROR_SOCKET_CREATE;
         srs_error("create linux socket error. port=%d, ret=%d", port, ret);

--- a/trunk/src/app/srs_app_listener.cpp
+++ b/trunk/src/app/srs_app_listener.cpp
@@ -120,15 +120,11 @@ int SrsUdpListener::listen()
     hints.ai_socktype = SOCK_DGRAM;
     hints.ai_flags    = AI_NUMERICHOST;
     addrinfo* result  = NULL;
-    puts("XXX-9");
     if(getaddrinfo(ip.c_str(), port_string, (const addrinfo*)&hints, &result) != 0) {
         ret = ERROR_SYSTEM_IP_INVALID;
-        puts("XXX-9-BAD!!!");
         srs_error("bad address. ret=%d", ret);
         return ret;
     }
-    puts("XXX-9-LISTEN-OK!");
-    printf("XXX-9- F=%d\n", result->ai_family);
     
     if ((_fd = socket(result->ai_family, result->ai_socktype, result->ai_protocol)) == -1) {
         ret = ERROR_SOCKET_CREATE;
@@ -242,15 +238,11 @@ int SrsTcpListener::listen()
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_flags    = AI_NUMERICHOST;
     addrinfo* result  = NULL;
-    printf("XXX-9b <ip=%s>",ip.c_str());
     if(getaddrinfo(ip.c_str(), port_string, (const addrinfo*)&hints, &result) != 0) {
         ret = ERROR_SYSTEM_IP_INVALID;
-        puts("XXX-9b-BAD!!!");
         srs_error("bad address. ret=%d", ret);
         return ret;
     }
-    puts("XXX-9b-LISTEN-OK!");
-    printf("XXX-9b- F=%d\n", result->ai_family);
 
     if ((_fd = socket(result->ai_family, result->ai_socktype, result->ai_protocol)) == -1) {
         ret = ERROR_SOCKET_CREATE;

--- a/trunk/src/app/srs_app_listener.cpp
+++ b/trunk/src/app/srs_app_listener.cpp
@@ -178,7 +178,7 @@ int SrsUdpListener::cycle()
     int ret = ERROR_SUCCESS;
 
     // TODO: FIXME: support ipv6, @see man 7 ipv6
-    sockaddr_in6 from;
+    sockaddr_storage from;
     int nb_from = sizeof(sockaddr_in6);
     int nread = 0;
 
@@ -187,7 +187,7 @@ int SrsUdpListener::cycle()
         return ret;
     }
     
-    if ((ret = handler->on_udp_packet(&from, buf, nread)) != ERROR_SUCCESS) {
+    if ((ret = handler->on_udp_packet((sockaddr*)&from, buf, nread)) != ERROR_SUCCESS) {
         srs_warn("handle udp packet failed. ret=%d", ret);
         return ret;
     }

--- a/trunk/src/app/srs_app_listener.cpp
+++ b/trunk/src/app/srs_app_listener.cpp
@@ -30,6 +30,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <netdb.h>
 using namespace std;
 
 #include <srs_kernel_log.hpp>
@@ -110,10 +111,28 @@ st_netfd_t SrsUdpListener::stfd()
 int SrsUdpListener::listen()
 {
     int ret = ERROR_SUCCESS;
+
+    char port_string[8];
+    snprintf(port_string, sizeof(port_string), "%d", port);
+    addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family   = AF_UNSPEC;
+    hints.ai_socktype = SOCK_DGRAM;
+    hints.ai_flags    = AI_NUMERICHOST;
+    addrinfo* result  = NULL;
+    puts("XXX-9");
+    if(getaddrinfo(ip.c_str(), port_string, (const addrinfo*)&hints, &result) != 0) {
+        ret = ERROR_SYSTEM_IP_INVALID;
+        puts("XXX-9-BAD!!!");
+        srs_error("bad address. ret=%d", ret);
+        return ret;
+    }
+    puts("XXX-9-LISTEN-OK!");
     
-    if ((_fd = socket(AF_INET, SOCK_DGRAM, 0)) == -1) {
+    if ((_fd = socket(result->ai_family, result->ai_socktype, result->ai_protocol)) == -1) {
         ret = ERROR_SOCKET_CREATE;
         srs_error("create linux socket error. ip=%s, port=%d, ret=%d", ip.c_str(), port, ret);
+        freeaddrinfo(result);
         return ret;
     }
     srs_verbose("create linux socket success. ip=%s, port=%d, fd=%d", ip.c_str(), port, _fd);
@@ -122,17 +141,15 @@ int SrsUdpListener::listen()
     if (setsockopt(_fd, SOL_SOCKET, SO_REUSEADDR, &reuse_socket, sizeof(int)) == -1) {
         ret = ERROR_SOCKET_SETREUSE;
         srs_error("setsockopt reuse-addr error. ip=%s, port=%d, ret=%d", ip.c_str(), port, ret);
+        freeaddrinfo(result);
         return ret;
     }
     srs_verbose("setsockopt reuse-addr success. ip=%s, port=%d, fd=%d", ip.c_str(), port, _fd);
     
-    sockaddr_in addr;
-    addr.sin_family = AF_INET;
-    addr.sin_port = htons(port);
-    addr.sin_addr.s_addr = inet_addr(ip.c_str());
-    if (bind(_fd, (const sockaddr*)&addr, sizeof(sockaddr_in)) == -1) {
+    if (bind(_fd, result->ai_addr, result->ai_addrlen) == -1) {
         ret = ERROR_SOCKET_BIND;
         srs_error("bind socket error. ep=%s:%d, ret=%d", ip.c_str(), port, ret);
+        freeaddrinfo(result);
         return ret;
     }
     srs_verbose("bind socket success. ep=%s:%d, fd=%d", ip.c_str(), port, _fd);
@@ -140,16 +157,19 @@ int SrsUdpListener::listen()
     if ((_stfd = st_netfd_open_socket(_fd)) == NULL){
         ret = ERROR_ST_OPEN_SOCKET;
         srs_error("st_netfd_open_socket open socket failed. ep=%s:%d, ret=%d", ip.c_str(), port, ret);
+        freeaddrinfo(result);
         return ret;
     }
     srs_verbose("st open socket success. ep=%s:%d, fd=%d", ip.c_str(), port, _fd);
     
     if ((ret = pthread->start()) != ERROR_SUCCESS) {
         srs_error("st_thread_create listen thread error. ep=%s:%d, ret=%d", ip.c_str(), port, ret);
+        freeaddrinfo(result);
         return ret;
     }
     srs_verbose("create st listen thread success, ep=%s:%d", ip.c_str(), port);
 
+    freeaddrinfo(result);
     return ret;
 }
 
@@ -158,8 +178,8 @@ int SrsUdpListener::cycle()
     int ret = ERROR_SUCCESS;
 
     // TODO: FIXME: support ipv6, @see man 7 ipv6
-    sockaddr_in from;
-    int nb_from = sizeof(sockaddr_in);
+    sockaddr_in6 from;
+    int nb_from = sizeof(sockaddr_in6);
     int nread = 0;
 
     if ((nread = st_recvfrom(_stfd, buf, nb_buf, (sockaddr*)&from, &nb_from, ST_UTIME_NO_TIMEOUT)) <= 0) {
@@ -213,9 +233,27 @@ int SrsTcpListener::listen()
 {
     int ret = ERROR_SUCCESS;
     
-    if ((_fd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
+    char port_string[8];
+    snprintf(port_string, sizeof(port_string), "%d", port);
+    addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family   = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags    = AI_NUMERICHOST;
+    addrinfo* result  = NULL;
+    puts("XXX-9");
+    if(getaddrinfo(ip.c_str(), port_string, (const addrinfo*)&hints, &result) != 0) {
+        ret = ERROR_SYSTEM_IP_INVALID;
+        puts("XXX-9-BAD!!!");
+        srs_error("bad address. ret=%d", ret);
+        return ret;
+    }
+    puts("XXX-9-LISTEN-OK!");
+    
+    if ((_fd = socket(result->ai_family, result->ai_socktype, result->ai_protocol)) == -1) {
         ret = ERROR_SOCKET_CREATE;
         srs_error("create linux socket error. port=%d, ret=%d", port, ret);
+        freeaddrinfo(result);
         return ret;
     }
     srs_verbose("create linux socket success. port=%d, fd=%d", port, _fd);
@@ -224,17 +262,15 @@ int SrsTcpListener::listen()
     if (setsockopt(_fd, SOL_SOCKET, SO_REUSEADDR, &reuse_socket, sizeof(int)) == -1) {
         ret = ERROR_SOCKET_SETREUSE;
         srs_error("setsockopt reuse-addr error. port=%d, ret=%d", port, ret);
+        freeaddrinfo(result);
         return ret;
     }
     srs_verbose("setsockopt reuse-addr success. port=%d, fd=%d", port, _fd);
     
-    sockaddr_in addr;
-    addr.sin_family = AF_INET;
-    addr.sin_port = htons(port);
-    addr.sin_addr.s_addr = inet_addr(ip.c_str());
-    if (bind(_fd, (const sockaddr*)&addr, sizeof(sockaddr_in)) == -1) {
+    if (bind(_fd, result->ai_addr, result->ai_addrlen) == -1) {
         ret = ERROR_SOCKET_BIND;
         srs_error("bind socket error. ep=%s:%d, ret=%d", ip.c_str(), port, ret);
+        freeaddrinfo(result);
         return ret;
     }
     srs_verbose("bind socket success. ep=%s:%d, fd=%d", ip.c_str(), port, _fd);
@@ -242,6 +278,7 @@ int SrsTcpListener::listen()
     if (::listen(_fd, SERVER_LISTEN_BACKLOG) == -1) {
         ret = ERROR_SOCKET_LISTEN;
         srs_error("listen socket error. ep=%s:%d, ret=%d", ip.c_str(), port, ret);
+        freeaddrinfo(result);
         return ret;
     }
     srs_verbose("listen socket success. ep=%s:%d, fd=%d", ip.c_str(), port, _fd);
@@ -249,16 +286,19 @@ int SrsTcpListener::listen()
     if ((_stfd = st_netfd_open_socket(_fd)) == NULL){
         ret = ERROR_ST_OPEN_SOCKET;
         srs_error("st_netfd_open_socket open socket failed. ep=%s:%d, ret=%d", ip.c_str(), port, ret);
+        freeaddrinfo(result);
         return ret;
     }
     srs_verbose("st open socket success. ep=%s:%d, fd=%d", ip.c_str(), port, _fd);
     
     if ((ret = pthread->start()) != ERROR_SUCCESS) {
         srs_error("st_thread_create listen thread error. ep=%s:%d, ret=%d", ip.c_str(), port, ret);
+        freeaddrinfo(result);
         return ret;
     }
     srs_verbose("create st listen thread success, ep=%s:%d", ip.c_str(), port);
     
+    freeaddrinfo(result);
     return ret;
 }
 

--- a/trunk/src/app/srs_app_listener.hpp
+++ b/trunk/src/app/srs_app_listener.hpp
@@ -35,7 +35,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <srs_app_st.hpp>
 #include <srs_app_thread.hpp>
 
-struct sockaddr_in;
+struct sockaddr;
 
 /**
 * the udp packet handler.
@@ -61,7 +61,7 @@ public:
     * @param nb_buf, the size of udp packet bytes.
     * @remark user should never use the buf, for it's a shared memory bytes.
     */
-    virtual int on_udp_packet(sockaddr_in* from, char* buf, int nb_buf) = 0;
+    virtual int on_udp_packet(sockaddr* from, char* buf, int nb_buf) = 0;
 };
 
 /**

--- a/trunk/src/app/srs_app_mpegts_udp.cpp
+++ b/trunk/src/app/srs_app_mpegts_udp.cpp
@@ -161,8 +161,8 @@ SrsMpegtsOverUdp::~SrsMpegtsOverUdp()
 
 int SrsMpegtsOverUdp::on_udp_packet(sockaddr_in* from, char* buf, int nb_buf)
 {
-    std::string peer_ip = inet_ntoa(from->sin_addr);
-    int peer_port = ntohs(from->sin_port);
+    std::string peer_ip = inet_ntop(from->sin_addr);
+    int peer_port = ntohs(from->sin6_port);
 
     // append to buffer.
     buffer->append(buf, nb_buf);

--- a/trunk/src/app/srs_app_mpegts_udp.hpp
+++ b/trunk/src/app/srs_app_mpegts_udp.hpp
@@ -32,7 +32,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #ifdef SRS_AUTO_STREAM_CASTER
 
-struct sockaddr_in;
+struct sockaddr;
 #include <string>
 #include <map>
 
@@ -108,7 +108,7 @@ public:
     virtual ~SrsMpegtsOverUdp();
 // interface ISrsUdpHandler
 public:
-    virtual int on_udp_packet(sockaddr_in* from, char* buf, int nb_buf);
+    virtual int on_udp_packet(sockaddr* from, char* buf, int nb_buf);
 private:
     virtual int on_udp_bytes(std::string host, int port, char* buf, int nb_buf);
 // interface ISrsTsHandler

--- a/trunk/src/app/srs_app_rtsp.cpp
+++ b/trunk/src/app/srs_app_rtsp.cpp
@@ -73,7 +73,7 @@ int SrsRtpConn::listen()
     return listener->listen();
 }
 
-int SrsRtpConn::on_udp_packet(sockaddr_in* from, char* buf, int nb_buf)
+int SrsRtpConn::on_udp_packet(sockaddr* from, char* buf, int nb_buf)
 {
     int ret = ERROR_SUCCESS;
 

--- a/trunk/src/app/srs_app_rtsp.cpp
+++ b/trunk/src/app/srs_app_rtsp.cpp
@@ -51,7 +51,7 @@ SrsRtpConn::SrsRtpConn(SrsRtspConn* r, int p, int sid)
     _port = p;
     stream_id = sid;
     // TODO: support listen at <[ip:]port>
-    listener = new SrsUdpListener(this, "0.0.0.0", p);
+    listener = new SrsUdpListener(this, (srs_check_ipv6() ? "::" : "0.0.0.0"), p);
     cache = new SrsRtpPacket();
     pprint = SrsPithyPrint::create_caster();
 }

--- a/trunk/src/app/srs_app_rtsp.hpp
+++ b/trunk/src/app/srs_app_rtsp.hpp
@@ -77,7 +77,7 @@ public:
     virtual int listen();
 // interface ISrsUdpHandler
 public:
-    virtual int on_udp_packet(sockaddr_in* from, char* buf, int nb_buf);
+    virtual int on_udp_packet(sockaddr* from, char* buf, int nb_buf);
 };
 
 /**

--- a/trunk/src/app/srs_app_server.cpp
+++ b/trunk/src/app/srs_app_server.cpp
@@ -1165,7 +1165,8 @@ int SrsServer::listen_stream_caster()
         }
         
         // TODO: support listen at <[ip:]port>
-        if ((ret = listener->listen("0.0.0.0", port)) != ERROR_SUCCESS) {
+        if ((ret = listener->listen(srs_check_ipv6() ? "::" : "0.0.0.0";
+                                    port)) != ERROR_SUCCESS) {
             srs_error("StreamCaster listen at port %d failed. ret=%d", port, ret);
             return ret;
         }

--- a/trunk/src/app/srs_app_utility.cpp
+++ b/trunk/src/app/srs_app_utility.cpp
@@ -30,6 +30,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <signal.h>
 #include <sys/wait.h>
 #include <math.h>
+#include <netdb.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
 
 #ifdef SRS_OSX
 #include <sys/sysctl.h>
@@ -54,15 +58,31 @@ using namespace std;
 int srs_socket_connect(string server, int port, int64_t timeout, st_netfd_t* pstfd)
 {
     int ret = ERROR_SUCCESS;
-    
+
     *pstfd = NULL;
     st_netfd_t stfd = NULL;
-    sockaddr_in addr;
+
+    char port_string[8];
+    snprintf(port_string, sizeof(port_string), "%d", port);
+    addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family   = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    addrinfo* result  = NULL;
+    puts("XXX-4");
+
+    if(getaddrinfo(server.c_str(), port_string, (const addrinfo*)&hints, &result) != 0) {
+        ret = ERROR_SYSTEM_IP_INVALID;
+        puts("XXX-4-BAD!!!");
+        srs_error("dns resolve server error, ip empty. ret=%d", ret);
+        return ret;
+    }
     
-    int sock = socket(AF_INET, SOCK_STREAM, 0);
-    if(sock == -1){
+    int sock = socket(result->ai_family, result->ai_socktype, result->ai_protocol);
+    if(sock == -1) {
         ret = ERROR_SOCKET_CREATE;
         srs_error("create socket error. ret=%d", ret);
+        freeaddrinfo(result);
         return ret;
     }
     
@@ -71,35 +91,21 @@ int srs_socket_connect(string server, int port, int64_t timeout, st_netfd_t* pst
     if(stfd == NULL){
         ret = ERROR_ST_OPEN_SOCKET;
         srs_error("st_netfd_open_socket failed. ret=%d", ret);
+        srs_close_stfd(stfd);
+        freeaddrinfo(result);
         return ret;
     }
     
-    // connect to server.
-    std::string ip = srs_dns_resolve(server);
-    if (ip.empty()) {
-        ret = ERROR_SYSTEM_IP_INVALID;
-        srs_error("dns resolve server error, ip empty. ret=%d", ret);
-        goto failed;
-    }
-    
-    addr.sin_family = AF_INET;
-    addr.sin_port = htons(port);
-    addr.sin_addr.s_addr = inet_addr(ip.c_str());
-    
-    if (st_connect(stfd, (const struct sockaddr*)&addr, sizeof(sockaddr_in), timeout) == -1){
+    if (st_connect(stfd, result->ai_addr, result->ai_addrlen, timeout) == -1){
         ret = ERROR_ST_CONNECT;
-        srs_error("connect to server error. ip=%s, port=%d, ret=%d", ip.c_str(), port, ret);
-        goto failed;
+        srs_error("connect to server error. server=%s, port=%d, ret=%d", server.c_str(), port, ret);
+        srs_close_stfd(stfd);
+        freeaddrinfo(result);
+        return ret;
     }
-    srs_info("connect ok. server=%s, ip=%s, port=%d", server.c_str(), ip.c_str(), port);
+    srs_info("connect ok. server=%s, port=%d", server.c_str(), port);
     
     *pstfd = stfd;
-    return ret;
-    
-failed:
-    if (stfd) {
-        srs_close_stfd(stfd);
-    }
     return ret;
 }
 
@@ -1341,74 +1347,84 @@ string srs_get_public_internet_address()
 
 string srs_get_local_ip(int fd)
 {
-    std::string ip;
-
+    puts("XXX-5");
     // discovery client information
-    sockaddr_in addr;
+    sockaddr_storage addr;
     socklen_t addrlen = sizeof(addr);
     if (getsockname(fd, (sockaddr*)&addr, &addrlen) == -1) {
-        return ip;
+        return "";
     }
     srs_verbose("get local ip success.");
 
-    // ip v4 or v6
-    char buf[INET6_ADDRSTRLEN];
-    memset(buf, 0, sizeof(buf));
-
-    if ((inet_ntop(addr.sin_family, &addr.sin_addr, buf, sizeof(buf))) == NULL) {
-        return ip;
+    char address_string[64];
+    const int success = getnameinfo((const sockaddr*)&addr, addrlen, 
+                                    (char*)&address_string, sizeof(address_string),
+                                    NULL, 0,
+                                    NI_NUMERICHOST);    
+    if(success != 0) {
+    puts("XXX-5-BAD!!!");
+        return "";
     }
 
-    ip = buf;
-
-    srs_verbose("get local ip of client ip=%s, fd=%d", buf, fd);
-
-    return ip;
+    puts("XXX-5-OK.");
+    srs_verbose("get local ip of client ip=%s, fd=%d", address_string, fd);
+    return std::string(address_string);
 }
 
 int srs_get_local_port(int fd)
 {
+    puts("XXX-6");
     // discovery client information
-    sockaddr_in addr;
+    sockaddr_storage addr;
     socklen_t addrlen = sizeof(addr);
     if (getsockname(fd, (sockaddr*)&addr, &addrlen) == -1) {
         return 0;
     }
     srs_verbose("get local ip success.");
-    
-    int port = ntohs(addr.sin_port);
 
-    srs_verbose("get local ip of client port=%s, fd=%d", port, fd);
+    int port = 0;
+    switch(addr.ss_family) {
+        case AF_INET:
+            port = ntohs(((sockaddr_in*)&addr)->sin_port);
+         break;
+        case AF_INET6:
+            port = ntohs(((sockaddr_in6*)&addr)->sin6_port);
+         break;
+    }
 
+    if(port == 0) {
+    puts("XXX-6-BAD!!!");
+    }
+    puts("XXX-6-OK.");
+
+    srs_verbose("get local port of client port=%s, fd=%d", port, fd);
     return port;
 }
 
 string srs_get_peer_ip(int fd)
 {
-    std::string ip;
-    
+    puts("XXX-8");
     // discovery client information
-    sockaddr_in addr;
+    sockaddr_storage addr;
     socklen_t addrlen = sizeof(addr);
-    if (getpeername(fd, (sockaddr*)&addr, &addrlen) == -1) {
-        return ip;
+    if (getsockname(fd, (sockaddr*)&addr, &addrlen) == -1) {
+        return "";
     }
-    srs_verbose("get peer name success.");
+    srs_verbose("get peer ip success.");
 
-    // ip v4 or v6
-    char buf[INET6_ADDRSTRLEN];
-    memset(buf, 0, sizeof(buf));
-    
-    if ((inet_ntop(addr.sin_family, &addr.sin_addr, buf, sizeof(buf))) == NULL) {
-        return ip;
+    char address_string[64];
+    const int success = getnameinfo((const sockaddr*)&addr, addrlen, 
+                                    (char*)&address_string, sizeof(address_string),
+                                    NULL, 0,
+                                    NI_NUMERICHOST);    
+    if(success != 0) {
+    puts("XXX-8-BAD!!!");
+        return "";
     }
-    srs_verbose("get peer ip of client ip=%s, fd=%d", buf, fd);
-    
-    ip = buf;
-    
-    srs_verbose("get peer ip success. ip=%s, fd=%d", ip.c_str(), fd);
-    
-    return ip;
+
+    puts("XXX-8-OK.");
+    srs_verbose("get peer ip of client ip=%s, fd=%d", address_string, fd);
+    return std::string(address_string);
 }
 
 bool srs_string_is_http(string url)

--- a/trunk/src/app/srs_app_utility.cpp
+++ b/trunk/src/app/srs_app_utility.cpp
@@ -214,7 +214,8 @@ string srs_path_build_timestamp(string template_path)
 
 void srs_parse_endpoint(string ip_port, string& ip, string& port)
 {
-    ip = "0.0.0.0";
+    ip = srs_check_ipv6() ? "::" : "0.0.0.0";
+    
     port = ip_port;
     
     size_t pos = string::npos;
@@ -1343,6 +1344,16 @@ string srs_get_public_internet_address()
     }
     
     return "";
+}
+
+int srs_check_ipv6()
+{
+    int sd = socket(AF_INET6, SOCK_DGRAM, 0);
+    if(sd >= 0) {
+        close(sd);
+        return 1;
+    }
+    return 0;
 }
 
 string srs_get_local_ip(int fd)

--- a/trunk/src/app/srs_app_utility.cpp
+++ b/trunk/src/app/srs_app_utility.cpp
@@ -69,11 +69,9 @@ int srs_socket_connect(string server, int port, int64_t timeout, st_netfd_t* pst
     hints.ai_family   = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
     addrinfo* result  = NULL;
-    puts("XXX-4");
 
     if(getaddrinfo(server.c_str(), port_string, (const addrinfo*)&hints, &result) != 0) {
         ret = ERROR_SYSTEM_IP_INVALID;
-        puts("XXX-4-BAD!!!");
         srs_error("dns resolve server error, ip empty. ret=%d", ret);
         return ret;
     }
@@ -1358,7 +1356,6 @@ int srs_check_ipv6()
 
 string srs_get_local_ip(int fd)
 {
-    puts("XXX-5");
     // discovery client information
     sockaddr_storage addr;
     socklen_t addrlen = sizeof(addr);
@@ -1373,18 +1370,15 @@ string srs_get_local_ip(int fd)
                                     NULL, 0,
                                     NI_NUMERICHOST);    
     if(success != 0) {
-    puts("XXX-5-BAD!!!");
         return "";
     }
 
-    puts("XXX-5-OK.");
     srs_verbose("get local ip of client ip=%s, fd=%d", address_string, fd);
     return std::string(address_string);
 }
 
 int srs_get_local_port(int fd)
 {
-    puts("XXX-6");
     // discovery client information
     sockaddr_storage addr;
     socklen_t addrlen = sizeof(addr);
@@ -1403,18 +1397,12 @@ int srs_get_local_port(int fd)
          break;
     }
 
-    if(port == 0) {
-    puts("XXX-6-BAD!!!");
-    }
-    puts("XXX-6-OK.");
-
     srs_verbose("get local port of client port=%s, fd=%d", port, fd);
     return port;
 }
 
 string srs_get_peer_ip(int fd)
 {
-    puts("XXX-8");
     // discovery client information
     sockaddr_storage addr;
     socklen_t addrlen = sizeof(addr);
@@ -1429,11 +1417,9 @@ string srs_get_peer_ip(int fd)
                                     NULL, 0,
                                     NI_NUMERICHOST);    
     if(success != 0) {
-    puts("XXX-8-BAD!!!");
         return "";
     }
 
-    puts("XXX-8-OK.");
     srs_verbose("get peer ip of client ip=%s, fd=%d", address_string, fd);
     return std::string(address_string);
 }

--- a/trunk/src/app/srs_app_utility.hpp
+++ b/trunk/src/app/srs_app_utility.hpp
@@ -663,6 +663,9 @@ extern std::vector<std::string>& srs_get_local_ipv4_ips();
 // get local public ip, empty string if no public internet address found.
 extern std::string srs_get_public_internet_address();
 
+// check for IPv6 support
+extern int srs_check_ipv6();
+
 // get local or peer ip.
 // where local ip is the server ip which client connected.
 extern std::string srs_get_local_ip(int fd);

--- a/trunk/src/kernel/srs_kernel_utility.cpp
+++ b/trunk/src/kernel/srs_kernel_utility.cpp
@@ -157,7 +157,6 @@ int64_t srs_update_system_time_ms()
 
 string srs_dns_resolve(string host, int& family)
 {
-    printf("XXX-3: <%s>\n", host.c_str());
     addrinfo hints;
     memset(&hints, 0, sizeof(hints));
     hints.ai_family  = family;
@@ -174,11 +173,9 @@ string srs_dns_resolve(string host, int& family)
     freeaddrinfo(result);
 
     if(success) {
-       printf("XXX-3 OK!: <%s> -> %s\n", host.c_str(), address_string);
        family = result->ai_family;
        return string(address_string);
     }
-    puts("XXX-3-BAD!!!!");
     return "";
 }
 

--- a/trunk/src/kernel/srs_kernel_utility.cpp
+++ b/trunk/src/kernel/srs_kernel_utility.cpp
@@ -157,23 +157,25 @@ int64_t srs_update_system_time_ms()
 
 string srs_dns_resolve(string host)
 {
-    if (inet_addr(host.c_str()) != INADDR_NONE) {
-        return host;
-    }
-    
-    hostent* answer = gethostbyname(host.c_str());
-    if (answer == NULL) {
+    printf("XXX-3: <%s>\n", host.c_str());
+    addrinfo* result  = NULL;
+    if(getaddrinfo(host.c_str(), NULL, NULL, &result) != 0) {
         return "";
     }
     
-    char ipv4[16];
-    memset(ipv4, 0, sizeof(ipv4));
-    for (int i = 0; i < answer->h_length; i++) {
-        inet_ntop(AF_INET, answer->h_addr_list[i], ipv4, sizeof(ipv4));
-        break;
+    char address_string[64];
+    const int success = getnameinfo(result->ai_addr, result->ai_addrlen, 
+                                    (char*)&address_string, sizeof(address_string),
+                                    NULL, 0,
+                                    NI_NUMERICHOST);
+    freeaddrinfo(result);
+
+    if(success) {
+       printf("XXX-3 OK!: <%s> -> %s\n", host.c_str(), address_string);
+       return string(address_string);
     }
-    
-    return ipv4;
+    puts("XXX-3-BAD!!!!");
+    return "";
 }
 
 bool srs_is_little_endian()

--- a/trunk/src/kernel/srs_kernel_utility.cpp
+++ b/trunk/src/kernel/srs_kernel_utility.cpp
@@ -155,10 +155,13 @@ int64_t srs_update_system_time_ms()
     return _srs_system_time_us_cache / 1000;
 }
 
-string srs_dns_resolve(string host)
+string srs_dns_resolve(string host, int& family)
 {
     printf("XXX-3: <%s>\n", host.c_str());
-    addrinfo* result  = NULL;
+    addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family  = family;
+    addrinfo* result = NULL;
     if(getaddrinfo(host.c_str(), NULL, NULL, &result) != 0) {
         return "";
     }
@@ -172,6 +175,7 @@ string srs_dns_resolve(string host)
 
     if(success) {
        printf("XXX-3 OK!: <%s> -> %s\n", host.c_str(), address_string);
+       family = result->ai_family;
        return string(address_string);
     }
     puts("XXX-3-BAD!!!!");

--- a/trunk/src/kernel/srs_kernel_utility.hpp
+++ b/trunk/src/kernel/srs_kernel_utility.hpp
@@ -50,7 +50,7 @@ extern int64_t srs_get_system_startup_time_ms();
 extern int64_t srs_update_system_time_ms();
 
 // dns resolve utility, return the resolved ip address.
-extern std::string srs_dns_resolve(std::string host);
+extern std::string srs_dns_resolve(std::string host, int& family);
 
 // whether system is little endian
 extern bool srs_is_little_endian();

--- a/trunk/src/libs/srs_lib_simple_socket.cpp
+++ b/trunk/src/libs/srs_lib_simple_socket.cpp
@@ -63,7 +63,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #endif
 
 #include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
 #include <errno.h>
+#include <string.h>
+#include <stdio.h>
 
 #include <srs_kernel_utility.hpp>
 
@@ -76,6 +80,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     struct SrsBlockSyncSocket
     {
         SOCKET fd;
+        int    family;
         int64_t recv_timeout;
         int64_t send_timeout;
         int64_t recv_bytes;

--- a/trunk/src/libs/srs_lib_simple_socket.cpp
+++ b/trunk/src/libs/srs_lib_simple_socket.cpp
@@ -137,16 +137,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         hints.ai_socktype = SOCK_STREAM;
         hints.ai_flags    = AI_NUMERICHOST;
         addrinfo* result  = NULL;
-        puts("XXX-2");
 
         if(getaddrinfo(server_ip, port_string, (const addrinfo*)&hints, &result) == 0) {
             if(::connect(skt->fd, result->ai_addr, result->ai_addrlen) < 0){
                 freeaddrinfo(result);
                 return ERROR_SOCKET_CONNECT;
             }
-        }
-        else {
-           puts("XXX-2-BAD!!!!");
         }
 
         freeaddrinfo(result);

--- a/trunk/src/libs/srs_lib_simple_socket.cpp
+++ b/trunk/src/libs/srs_lib_simple_socket.cpp
@@ -132,28 +132,24 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         char port_string[8];
         snprintf(port_string, sizeof(port_string), "%d", port);
         addrinfo hints;
-        memset(&hints, sizeof(hints), 0);
+        memset(&hints, 0, sizeof(hints));
         hints.ai_family   = skt->family;
         hints.ai_socktype = SOCK_STREAM;
         hints.ai_flags    = AI_NUMERICHOST;
         addrinfo* result  = NULL;
         puts("XXX-2");
 
-        if(getaddrinfo(server_ip, port_string, hints, &result) == 0) {
-            sockaddr_in6 addr;
-            addr.sin6_family = AF_INET6;
-            addr.sin6_port  = htons(port);
-            addr.sin6_addr  = inet_addr(server_ip);
-
+        if(getaddrinfo(server_ip, port_string, (const addrinfo*)&hints, &result) == 0) {
             if(::connect(skt->fd, result->ai_addr, result->ai_addrlen) < 0){
+                freeaddrinfo(result);
                 return ERROR_SOCKET_CONNECT;
             }
         }
         else {
            puts("XXX-2-BAD!!!!");
-           abort();
         }
 
+        freeaddrinfo(result);
         return ERROR_SUCCESS;
     }
     int srs_hijack_io_read(srs_hijack_io_t ctx, void* buf, size_t size, ssize_t* nread)

--- a/trunk/src/libs/srs_librtmp.cpp
+++ b/trunk/src/libs/srs_librtmp.cpp
@@ -24,6 +24,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <srs_librtmp.hpp>
 
 #include <stdlib.h>
+#include <sys/socket.h>
 
 // for srs-librtmp, @see https://github.com/ossrs/srs/issues/213
 #ifndef _WIN32
@@ -491,7 +492,8 @@ int srs_librtmp_context_resolve_host(Context* context)
     }
     
     // connect to server:port
-    context->ip = srs_dns_resolve(context->host);
+    int family = AF_UNSPEC;
+    context->ip = srs_dns_resolve(context->host, family);
     if (context->ip.empty()) {
         return -1;
     }

--- a/trunk/src/libs/srs_librtmp.cpp
+++ b/trunk/src/libs/srs_librtmp.cpp
@@ -322,12 +322,10 @@ struct Context
      */
     const char* inet_ntop(int af, const void *src, char *dst, socklen_t size)
     {
-        puts("XXX-1");
         switch (af) {
         case AF_INET:
             return (inet_ntop4( (unsigned char*)src, (char*)dst, size));
         case AF_INET6:
-           puts("XXX-1-v6");
            return (char*)(inet_ntop6( (unsigned char*)src, (char*)dst, size));
         default:
             return (NULL);

--- a/trunk/src/libs/srs_librtmp.cpp
+++ b/trunk/src/libs/srs_librtmp.cpp
@@ -321,17 +321,15 @@ struct Context
      */
     const char* inet_ntop(int af, const void *src, char *dst, socklen_t size)
     {
+        puts("XXX-1");
         switch (af) {
         case AF_INET:
-            return (inet_ntop4( (unsigned char*)src, (char*)dst, size)); // ****
-    #ifdef AF_INET6
-        #error "IPv6 not supported"
-        //case AF_INET6:
-        //    return (char*)(inet_ntop6( (unsigned char*)src, (char*)dst, size)); // ****
-    #endif
+            return (inet_ntop4( (unsigned char*)src, (char*)dst, size));
+        case AF_INET6:
+           puts("XXX-1-v6");
+           return (char*)(inet_ntop6( (unsigned char*)src, (char*)dst, size));
         default:
-            // return (NULL); // ****
-            return 0 ; // ****
+            return (NULL);
         }
         /* NOTREACHED */
     }

--- a/trunk/test-client
+++ b/trunk/test-client
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-mplayer rtmp://127.0.0.1:1935/live/livestream
+ffplay rtmp://127.0.0.1:1935/live/livestream

--- a/trunk/test-client
+++ b/trunk/test-client
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+mplayer rtmp://127.0.0.1:1935/live/livestream

--- a/trunk/test-client6
+++ b/trunk/test-client6
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+mplayer rtmp://ip6-localhost:1935/live/livestream

--- a/trunk/test-client6
+++ b/trunk/test-client6
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-mplayer rtmp://ip6-localhost:1935/live/livestream
+ffplay rtmp://ip6-localhost:1935/live/livestream

--- a/trunk/test-client6
+++ b/trunk/test-client6
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-ffplay rtmp://ip6-localhost:1935/live/livestream
+ffplay rtmp://[::1]:1935/live/livestream

--- a/trunk/test-ffmpeg
+++ b/trunk/test-ffmpeg
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+for((;;)); do
+   ffmpeg -re -i ./doc/source.200kbps.768x320.flv \
+      -vcodec copy -acodec copy \
+      -f flv -y rtmp://127.0.0.1/live/livestream;
+   sleep 1
+done

--- a/trunk/test-ffmpeg6
+++ b/trunk/test-ffmpeg6
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+for((;;)); do
+   ffmpeg -re -i ./doc/source.200kbps.768x320.flv \
+      -vcodec copy -acodec copy \
+      -f flv -y rtmp://[::1]/live/livestream;
+   sleep 1
+done

--- a/trunk/test-srs
+++ b/trunk/test-srs
@@ -1,0 +1,2 @@
+#!/bin/sh
+./objs/srs -c conf/rtmp.conf

--- a/trunk/test-srs
+++ b/trunk/test-srs
@@ -1,2 +1,6 @@
 #!/bin/sh
+
+killall -KILL srs
+
+rm -f core
 ./objs/srs -c conf/rtmp.conf


### PR DESCRIPTION
This pull request adds IPv6 support to SRS.

Test with:
1. Start SRS:
./objs/srs -c conf/rtmp.conf
2. Start ffmpeg:
for((;;)); do
   ffmpeg -re -i ./doc/source.200kbps.768x320.flv \
      -vcodec copy -acodec copy \
      -f flv -y rtmp://127.0.0.1/live/livestream;
   sleep 1
done
3. Start ffplay:
ffplay rtmp://[::1]:1935/live/livestream